### PR TITLE
use relative submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "fablab-document"]
 	path = fablab-document
-	url = git@github.com:fau-fablab/fablab-document.git
+	url = ../../fau-fablab/fablab-document.git


### PR DESCRIPTION
bisher wurde immer SSH für die submodule-URL verwendet. Das funktionierte bei HTTPS / GitHub Desktop nicht.