### PR TITLE
Hinweis zur Beschädigung der Magnetencoder und Tippfehler

### DIFF
--- a/Einweisung_Lasercutter.tex
+++ b/Einweisung_Lasercutter.tex
@@ -107,6 +107,7 @@ Den Inhalt dieses Kapitels musst du wissen, alles andere kannst du bei Bedarf na
  \item Die Schrauben zur Befestigung des Schneidetischs (Wabengitter) dürfen gedreht werden, ansonsten nichts schrauben oder verstellen. \todo{Diese durch Rändelschrauben ersetzen, um Verwechslungen zu vermeiden, und grün markieren (z.\,B. Plotterfolie um die Soll-Position) damit wir den gleichen Text wie beim Zing verwenden können}
  \item \nurZing Die grün markierten Rändelschrauben am Schneidetisch dürfen von Hand gedreht werden, ansonsten nichts verstellen. % Betätigen der grünen Schrauben ist nötig, um den Schneidetisch zu reinigen! Deshalb kann man es nicht ganz verbieten.
  \item Im Brandfall nur mit CO\subscript{2}-Löscher, niemals mit Pulver-, Schaum- oder Wasserlöscher löschen (Verschmutzung, Stromschlaggefahr)! Der Feuerlöscher steht direkt neben dem Lasercutter.
+ \item \nurLTT Keine Magneten in die Nähe der Achsen bringen! Der Laser arbeitet mit einem magnetischen Positionierungssystem, welches dadurch beschädigt werden kann.
  \item \nurLTT \todo{...}
  \item \nurLTT Sofortiges Abschalten des Lasercutters geht nur mit dem Not-Aus-Schalter. \laserLTTPause fährt die aktuellen Linien noch zu Ende!
  \item \nurZing Es gibt keinen Not-Aus-Schalter! \laserZingStop  fährt die aktuelle Linie noch zu Ende. Sofortiges Abschalten des Lasercutters geht nur über den Kippschalter rechts unten am Gerät.

--- a/Einweisung_Lasercutter.tex
+++ b/Einweisung_Lasercutter.tex
@@ -551,7 +551,10 @@ Bisher wurden gute Erfahrungen mit folgenden Seiten gemacht:
 
 
 \subsection{Schnittmuster platzsparend anordnen}
-\url{https://svgnest.com/} (im Browser) oder \url{https://deepnest.io/} (zum Installieren).
+Je nach Design kann Platz gespart werden, wenn auszuschneidende Objekte
+\enquote{ineinander} geschoben werden.
+Diese mühselige Aufgabe kann von verschiedenen Programmen übernommen werden.
+Beispiele sind \url{https://svgnest.com/} (im Browser) oder \url{https://deepnest.io/} (zum Installieren).
 
 
 \newpage

--- a/Einweisung_Lasercutter.tex
+++ b/Einweisung_Lasercutter.tex
@@ -101,10 +101,10 @@ Den Inhalt dieses Kapitels musst du wissen, alles andere kannst du bei Bedarf na
 \subsection{Regeln und Hinweise}
 \begin{itemize}
  \item Nur zweifelsfrei geeignete Materialien verwenden, die in der Liste (auf den nächsten Seiten) stehen. Keine unbekannten Materialien, kein PVC, Teflon, etc.
- \item Ebenfalls nicht erlaubt sind leichtentzündliche oder gefährliche Dinge, wie z.B. gefüllte Feuer\-zeuge. Wenn das Gehäuse nicht aus Metall ist, muss bei Handys der Akku herausgenommen werden.
+ \item Ebenfalls nicht erlaubt sind leichtentzündliche oder gefährliche Dinge, wie z.\,B. gefüllte Feuer\-zeuge. Wenn das Gehäuse nicht aus Metall ist, muss bei Handys der Akku herausgenommen werden.
  \item Lasercutter nur unter ständiger Beobachtung betreiben! Solange der Laser aktiv ist, muss immer eine Person \emph{direkt} beim Lasercutter sein. Für vollständig unbrennbare Materialien (Glas, nicht lackierte Metallteile) gibt es eine Ausnahme, wenn vorher alle brennbaren Reste aus dem Schneidetisch entleert wurden.
  \item Alle Arbeiten erfolgen auf eigenes Risiko, auch wenn dein schickes Handy beim Gravieren kaputtgeht.
- \item Die Schrauben zur Befestigung des Schneidetischs (Wabengitter) dürfen gedreht werden, ansonsten nichts schrauben oder verstellen. \todo{Diese durch Rändelschrauben ersetzen, um Verwechslungen zu vermeiden, und grün markieren (z.B. Plotterfolie um die Soll-Position) damit wir den gleichen Text wie beim Zing verwenden können}
+ \item Die Schrauben zur Befestigung des Schneidetischs (Wabengitter) dürfen gedreht werden, ansonsten nichts schrauben oder verstellen. \todo{Diese durch Rändelschrauben ersetzen, um Verwechslungen zu vermeiden, und grün markieren (z.\,B. Plotterfolie um die Soll-Position) damit wir den gleichen Text wie beim Zing verwenden können}
  \item \nurZing Die grün markierten Rändelschrauben am Schneidetisch dürfen von Hand gedreht werden, ansonsten nichts verstellen. % Betätigen der grünen Schrauben ist nötig, um den Schneidetisch zu reinigen! Deshalb kann man es nicht ganz verbieten.
  \item Im Brandfall nur mit CO\subscript{2}-Löscher, niemals mit Pulver-, Schaum- oder Wasserlöscher löschen (Verschmutzung, Stromschlaggefahr)! Der Feuerlöscher steht direkt neben dem Lasercutter.
  \item \nurLTT \todo{...}
@@ -129,7 +129,7 @@ Bei \emph{größeren} Flammen oder starker Rauchentwicklung muss das Lasern \emp
  \item \textbf{Deckel leicht öffnen} (Laser wird ausgeschaltet, der Antrieb fährt jedoch weiter).\\
  \nurLTT Oder auch den Not-Aus betätigen.
  \item \textbf{Betreuer rufen}
- \item Letzer Ausweg ist das Löschen mit dem CO\subscript{2}-Löscher in kurzen Sprühstößen. Ein Feuerlöscher befindet sich beim Kassenterminal gleich gegenüber vom Lasercutter, sowie am Durchgang zur Elektrowerkstatt.
+ \item Letzter Ausweg ist das Löschen mit dem CO\subscript{2}-Löscher in kurzen Sprühstößen. Ein Feuerlöscher befindet sich beim Kassenterminal gleich gegenüber vom Lasercutter, sowie am Durchgang zur Elektrowerkstatt.
  \item Bei weiterer Eskalation die Feuerwehr rufen, anwesende Personen warnen und den Raum verlassen (Erstickungsgefahr durch CO\subscript{2} und durch Rauch)
 \end{itemize}
 
@@ -174,11 +174,11 @@ Wenn ein Material nicht zweifelsfrei erlaubt ist, frage unbedingt nach! Viele Ku
 \itemCross spritzendes oder stark wässriges Material (Schokolade, ...)
 \itemCross ABS, Epoxidharz (GFK, CFK, Platinen), weil es übelst stinkt
 \itemCross PS Polystyrol / PC Polycarbonat dicker als 1\,mm, weil es beim Lasern spritzt
-\itemCross halogenhaltige Kunststoffe: PVC = Vinyl = Neopren, PTFE = Teflon (z.B. als \enquote{glitschige} Beschichtung von Taschenmessern), PFA, ...
+\itemCross halogenhaltige Kunststoffe: PVC = Vinyl = Neopren, PTFE = Teflon (z.\,B. als \enquote{glitschige} Beschichtung von Taschenmessern), PFA, ...
 \end{itemize}
 
 \section{Grundlagen}
-Der Lasercutter hat zwei Laser: Einen roten Laserpointer, der weitestgehend harmlos ist. Dieser ist wie ein Laserpointer ungefährlich, solange man man den direkten Strahl (z.B. mit einem Spiegel) höchstens für sehr kurze Zeit betrachtet. Das Betrachten des roten Punkts auf einem Objekt ist harmlos.
+Der Lasercutter hat zwei Laser: Einen roten Laserpointer, der weitestgehend harmlos ist. Dieser ist wie ein Laserpointer ungefährlich, solange man den direkten Strahl (z.\,B. mit einem Spiegel) höchstens für sehr kurze Zeit betrachtet. Das Betrachten des roten Punkts auf einem Objekt ist harmlos.
 
 Der eigentliche Laser (Infrarot mit hoher Leistung) wird sofort abgeschaltet, wenn Schutzscheibe oder Frontklappe geöffnet sind. Von ihm geht keine Gefahr aus, solange die Schutzschalter nicht manipuliert werden. Daher: keine Magneten an der Vorder- und Oberseite des Lasercutters anbringen.
 
@@ -196,7 +196,7 @@ Wenn du Inkscape verwendest, wähle möglichst folgende Aufteilung, damit du es 
 
 \textbf{Linie markieren}: Linienfarbe grün, keine Füllung.
 
-\textbf{Kommentare}: Linienfarbe oder Füllung blau. So kannst du z.B. Erklärungstexte mit in deine Datei einbauen, die nicht gelasert werden sollen.
+\textbf{Kommentare}: Linienfarbe oder Füllung blau. So kannst du z.\,B. Erklärungstexte mit in deine Datei einbauen, die nicht gelasert werden sollen.
 
 Bringe die Datei als SVG mit. Wenn du Schriftarten verwendest, die wir im FabLab nicht installiert haben, wandle den Text in Pfade um.
 
@@ -300,7 +300,7 @@ Neben Visicut gibt es auch die kompliziertere Möglichkeit, den Lasercutter übe
 Neben Visicut gibt es auch die Möglichkeit, den Lasercutter über einen Windows-Druckertreiber (Epilog Engraver Win32 Zing) anzusprechen. Wenn es nicht bereits läuft, beim Steuerrechner auf dem Desktop \enquote{Wolfgang} %TODO wie heißt die Verknüpfung atm?
  öffnen und etwas Geduld haben.
 
-Drucken kann man nur aus aus Adobe Reader 9 (Datei vorher nach PDF exportieren, geht gut für Inkscape) und Corel Draw (Import anderer Formate funktioniert nicht gescheit).  Das direkte Drucken aus anderen Programmen heraus, z.B. Inkscape, ist nicht möglich!
+Drucken kann man nur aus aus Adobe Reader 9 (Datei vorher nach PDF exportieren, geht gut für Inkscape) und Corel Draw (Import anderer Formate funktioniert nicht gescheit).  Das direkte Drucken aus anderen Programmen heraus, z.\,B. Inkscape, ist nicht möglich!
 
 Die Datei mit Adobe Reader bzw.\  Corel Draw öffnen, die Freigabe ist unter Computer$\rightarrow$Z:\textbackslash \ zu finden. Bei Datei$\rightarrow$Drucken \textit{Epilog Engraver} auswählen und in den Druckereinstellungen alles auf das aktuelle Material einstellen:
 
@@ -341,8 +341,8 @@ Auf der folgenden Zeichnung ist dies dargestellt: Der dick umrandete Kasten ist 
   \mittelpunktsZeichnung{Seitenmitte}{für Spezialfälle - die Seitengröße kann auch entsprechend kleiner gewählt werden}{./img/mittelpunkt-seitenmitte.pdf}
 \end{tabularx}
 \begin{tabularx}{\textwidth}{XXX}
-  \mittelpunktsZeichnung{Links-Mitte}{für Beschriftungen, z.B. in x-Richtung liegende Kugelschreiber}{./img/mittelpunkt-linksmitte.pdf} &
-  \mittelpunktsZeichnung{Oben-Mitte}{für Beschriftungen, z.B. in y-Richtung liegende Kugelschreiber }{./img/mittelpunkt-obenmitte.pdf} &
+  \mittelpunktsZeichnung{Links-Mitte}{für Beschriftungen, z.\,B. in x-Richtung liegende Kugelschreiber}{./img/mittelpunkt-linksmitte.pdf} &
+  \mittelpunktsZeichnung{Oben-Mitte}{für Beschriftungen, z.\,B. in y-Richtung liegende Kugelschreiber }{./img/mittelpunkt-obenmitte.pdf} &
   \mittelpunktsZeichnung{Mitte-Mitte}{für Beschriftungen}{./img/mittelpunkt-mittemitte.pdf}
 \end{tabularx}
 
@@ -354,7 +354,7 @@ Wenn alle Einstellungen passen, Lasercutter einschalten (rechts hinten am Gerät
 \section{Job ausführen}
 
 \subsection{Material}
-Material gibt es im Lagerregal und in den Schubladen nebenan. Spezielle Verarbeitungshinweise finden sich im Wiki. Platten kann man einfach auf den Schneidetisch legen, entstehender Rauch wird dann nach unten und hinten abgesaugt. An den Stellen, an denen der Laser auf das Gitter trifft, gibt es beim Schneiden Reflexionen, die z.B. bei durchsichtigem Acryl störende kleine Macken an Schnittkanten erzeugen können. Um dies zu umgehen, gibt es allerlei Tricks mit Abstandshaltern, die im Wiki dokumentiert sind.
+Material gibt es im Lagerregal und in den Schubladen nebenan. Spezielle Verarbeitungshinweise finden sich im Wiki. Platten kann man einfach auf den Schneidetisch legen, entstehender Rauch wird dann nach unten und hinten abgesaugt. An den Stellen, an denen der Laser auf das Gitter trifft, gibt es beim Schneiden Reflexionen, die z.\,B. bei durchsichtigem Acryl störende kleine Macken an Schnittkanten erzeugen können. Um dies zu umgehen, gibt es allerlei Tricks mit Abstandshaltern, die im Wiki dokumentiert sind.
 
 %TODO Schneidetisch, Befestigung bauen
 
@@ -556,7 +556,7 @@ Bisher wurden gute Erfahrungen mit folgenden Seiten gemacht:
 
 \newpage
 \section{Hinweise für Betreuer: Wartung - LTT iLaser}
-In Härtefällen, z.B. wenn ein kompletter Auftrag fehlgeschlagen ist, können von einem Betreuer die Kosten für die Laufzeit gemindert oder erlassen werden.
+In Härtefällen, z.\,B. wenn ein kompletter Auftrag fehlgeschlagen ist, können von einem Betreuer die Kosten für die Laufzeit gemindert oder erlassen werden.
 
 \textbf{Achtung! Mache folgendes nur, wenn du wirklich Ahnung hast -- Fehler können teuer werden!}
 
@@ -572,7 +572,7 @@ Normale Reinigung der Optik und Mechanik siehe Benutzerhandbuch des Herstellers.
 \subsection{wöchentliche Reinigung: Linse, Spiegel, Wagen}
 \begin{itemize}
 \label{linsenreinigung}
- \item Auf den Schneidetisch etwas weiches legen, z.B. ein Stück altes Sweatshirt oder eine ausgebreitete Zeitung.
+ \item Auf den Schneidetisch etwas weiches legen, z.\,B. ein Stück altes Sweatshirt oder eine ausgebreitete Zeitung.
  \item ggf. Schneidetisch runterfahren
  \item Linse herausschrauben, entnehmen und mit der Gewinde-Seite nach unten auf den Tisch legen.
  \item 3-5 Tropfen Linsenreiniger auf Wattestäbchen aufbringen. Nur den originalen Reiniger verwenden, dieser ist 25 Prozent Isopropanol in demineralisiertem Wasser gelöst.


### PR DESCRIPTION
Behebt hauptsächlich Tippfehler (und führt halbe Leerzeichen bei z.B. ein).
Außerdem wurde der Hinweis auf Beschädigung der Magnetencoder hinzugefügt.